### PR TITLE
Lenk til vedtaksstotte ved klikk på bruker

### DIFF
--- a/src/components/user-table/body/status/utkast-status-data.tsx
+++ b/src/components/user-table/body/status/utkast-status-data.tsx
@@ -1,0 +1,50 @@
+import { Bleed, BodyShort } from '@navikt/ds-react';
+import { ChatElipsisIcon, ChatExclamationmarkIcon, PersonPlusIcon } from '@navikt/aksel-icons';
+import { UtkastStatus } from '../../../../rest/data/bruker';
+import { mapBrukerStatusTilTekst } from '../../../../utils';
+
+interface Props {
+	status: UtkastStatus;
+}
+
+export const UtkastStatusData = ({ status }: Props) => {
+	let StatusIkon;
+
+	switch (status) {
+		case UtkastStatus.TRENGER_BESLUTTER:
+			StatusIkon = (
+				<Bleed marginBlock="1 2" asChild>
+					<PersonPlusIcon title="Trenger kvalitetssikrer-ikon" className="status_ikon" />
+				</Bleed>
+			);
+			break;
+		case UtkastStatus.KLAR_TIL_BESLUTTER:
+			StatusIkon = (
+				<Bleed marginBlock="0 3" asChild>
+					<ChatExclamationmarkIcon title="Venter på tilbakemelding-ikon" className="status_ikon" />
+				</Bleed>
+			);
+			break;
+		case UtkastStatus.KLAR_TIL_VEILEDER:
+			StatusIkon = (
+				<Bleed marginBlock="0 3" asChild>
+					<ChatElipsisIcon title="Venter på veileder-ikon" className="status_ikon" />
+				</Bleed>
+			);
+			break;
+		case UtkastStatus.GODKJENT_AV_BESLUTTER:
+			StatusIkon = (
+				<Bleed marginBlock="0 3" asChild>
+					<ChatElipsisIcon title="Godkjent av kvalitetssikrer-ikon" className="status_ikon" />
+				</Bleed>
+			);
+			break;
+	}
+
+	return (
+		<span role="cell" className={'status'}>
+			{StatusIkon}
+			<BodyShort size="small">{mapBrukerStatusTilTekst(status)}</BodyShort>
+		</span>
+	);
+};

--- a/src/components/user-table/body/user-table-body.tsx
+++ b/src/components/user-table/body/user-table-body.tsx
@@ -10,7 +10,7 @@ export const UserTableBody = ({ brukere }: UserTableBodyProps) => {
 	return (
 		<div role="rowgroup" className="user-table-body">
 			{brukere.map((bruker, idx) => (
-				<UserRow idx={idx} bruker={bruker} key={idx} />
+				<UserRow idx={idx} bruker={bruker} key={bruker.brukerFnr} />
 			))}
 		</div>
 	);

--- a/src/components/user-table/body/user-table-body.tsx
+++ b/src/components/user-table/body/user-table-body.tsx
@@ -1,18 +1,16 @@
 import { UserRow } from './user-table-row';
 import { Bruker } from '../../../rest/data/bruker';
-import { OrNothing } from '../../../utils/types/ornothing';
 import './user-table-body.less';
 
 interface UserTableBodyProps {
 	brukere: Bruker[];
-	aktivEnhet: OrNothing<string>;
 }
 
-export const UserTableBody = (props: UserTableBodyProps) => {
+export const UserTableBody = ({ brukere }: UserTableBodyProps) => {
 	return (
 		<div role="rowgroup" className="user-table-body">
-			{props.brukere.map((bruker, idx) => (
-				<UserRow idx={idx} bruker={bruker} aktivEnhet={props.aktivEnhet} key={idx} />
+			{brukere.map((bruker, idx) => (
+				<UserRow idx={idx} bruker={bruker} key={idx} />
 			))}
 		</div>
 	);

--- a/src/components/user-table/body/user-table-row.tsx
+++ b/src/components/user-table/body/user-table-row.tsx
@@ -1,12 +1,17 @@
+import { Bleed, BodyShort, CopyButton, Tooltip } from '@navikt/ds-react';
+import { ChatElipsisIcon, ChatExclamationmarkIcon, PersonPlusIcon } from '@navikt/aksel-icons';
 import { Bruker, UtkastStatus } from '../../../rest/data/bruker';
 import { formatDateStr, formatDateStrWithMonthName, formatTimeStr } from '../../../utils/date-utils';
 import { capitalize, fjernNavFraEnhetNavn, lagBrukerNavn, mapBrukerStatusTilTekst } from '../../../utils';
 import { BrukerDirektelenkeMedFeilmelding } from '../bruker-direktelenke-med-feilmelding';
-import { Bleed, BodyShort, CopyButton, Tooltip } from '@navikt/ds-react';
-import { ChatElipsisIcon, ChatExclamationmarkIcon, PersonPlusIcon } from '@navikt/aksel-icons';
 import './user-table-body.less';
 
-export const UserRow = (props: { idx: number; bruker: Bruker }) => {
+interface UserRowProps {
+	idx: number;
+	bruker: Bruker;
+}
+
+export const UserRow = ({ idx, bruker }: UserRowProps) => {
 	const {
 		brukerFnr,
 		brukerFornavn,
@@ -17,13 +22,13 @@ export const UserRow = (props: { idx: number; bruker: Bruker }) => {
 		beslutterNavn,
 		veilederNavn,
 		status
-	} = props.bruker;
+	} = bruker;
 
 	const erMaskert = brukerFnr === '';
 
 	return (
 		// idx starter på 0, men gyldige verdier for aria-rowindex er 1 og oppover
-		<div role="row" aria-rowindex={props.idx + 1} className="user-table-row">
+		<div role="row" aria-rowindex={idx + 1} className="user-table-row">
 			<div className="user-table-row__innhold">
 				<Bleed marginBlock="2" style={{ display: 'flex' }}>
 					{!erMaskert && (
@@ -54,9 +59,13 @@ export const UserRow = (props: { idx: number; bruker: Bruker }) => {
 	);
 };
 
-const UtkastStatusData = (props: { status: UtkastStatus }) => {
+interface UtkastStatusDataProps {
+	status: UtkastStatus;
+}
+
+const UtkastStatusData = ({ status }: UtkastStatusDataProps) => {
 	let StatusIkon;
-	switch (props.status) {
+	switch (status) {
 		case UtkastStatus.TRENGER_BESLUTTER:
 			StatusIkon = (
 				<Bleed marginBlock="1 2" asChild>
@@ -90,7 +99,7 @@ const UtkastStatusData = (props: { status: UtkastStatus }) => {
 	return (
 		<span role="cell" className={'status'}>
 			{StatusIkon}
-			<BodyShort size="small">{mapBrukerStatusTilTekst(props.status)}</BodyShort>
+			<BodyShort size="small">{mapBrukerStatusTilTekst(status)}</BodyShort>
 		</span>
 	);
 };

--- a/src/components/user-table/body/user-table-row.tsx
+++ b/src/components/user-table/body/user-table-row.tsx
@@ -1,14 +1,12 @@
 import { Bruker, UtkastStatus } from '../../../rest/data/bruker';
 import { formatDateStr, formatDateStrWithMonthName, formatTimeStr } from '../../../utils/date-utils';
 import { capitalize, fjernNavFraEnhetNavn, lagBrukerNavn, mapBrukerStatusTilTekst } from '../../../utils';
-import { OrNothing } from '../../../utils/types/ornothing';
 import { BrukerDirektelenkeMedFeilmelding } from '../bruker-direktelenke-med-feilmelding';
 import { Bleed, BodyShort, CopyButton, Tooltip } from '@navikt/ds-react';
 import { ChatElipsisIcon, ChatExclamationmarkIcon, PersonPlusIcon } from '@navikt/aksel-icons';
 import './user-table-body.less';
 
-export const UserRow = (props: { idx: number; bruker: Bruker; aktivEnhet: OrNothing<string> }) => {
-	const { aktivEnhet } = props;
+export const UserRow = (props: { idx: number; bruker: Bruker }) => {
 	const {
 		brukerFnr,
 		brukerFornavn,
@@ -30,7 +28,6 @@ export const UserRow = (props: { idx: number; bruker: Bruker; aktivEnhet: OrNoth
 				<Bleed marginBlock="2" style={{ display: 'flex' }}>
 					{!erMaskert && (
 						<BrukerDirektelenkeMedFeilmelding
-							enhet={aktivEnhet}
 							fnr={brukerFnr}
 							knappTekst={`${capitalize(lagBrukerNavn(brukerEtternavn, brukerFornavn))}`}
 						/>

--- a/src/components/user-table/body/user-table-row.tsx
+++ b/src/components/user-table/body/user-table-row.tsx
@@ -1,17 +1,17 @@
 import { Bleed, BodyShort, CopyButton, Tooltip } from '@navikt/ds-react';
-import { ChatElipsisIcon, ChatExclamationmarkIcon, PersonPlusIcon } from '@navikt/aksel-icons';
-import { Bruker, UtkastStatus } from '../../../rest/data/bruker';
+import { Bruker } from '../../../rest/data/bruker';
 import { formatDateStr, formatDateStrWithMonthName, formatTimeStr } from '../../../utils/date-utils';
-import { capitalize, fjernNavFraEnhetNavn, lagBrukerNavn, mapBrukerStatusTilTekst } from '../../../utils';
+import { capitalize, fjernNavFraEnhetNavn, lagBrukerNavn } from '../../../utils';
 import { BrukerDirektelenkeMedFeilmelding } from '../bruker-direktelenke-med-feilmelding';
+import { UtkastStatusData } from './status/utkast-status-data';
 import './user-table-body.less';
 
-interface UserRowProps {
+interface Props {
 	idx: number;
 	bruker: Bruker;
 }
 
-export const UserRow = ({ idx, bruker }: UserRowProps) => {
+export const UserRow = ({ idx, bruker }: Props) => {
 	const {
 		brukerFnr,
 		brukerFornavn,
@@ -56,50 +56,5 @@ export const UserRow = ({ idx, bruker }: UserRowProps) => {
 				<BodyShort size="small">{fjernNavFraEnhetNavn(brukerOppfolgingsenhetNavn)}</BodyShort>
 			</div>
 		</div>
-	);
-};
-
-interface UtkastStatusDataProps {
-	status: UtkastStatus;
-}
-
-const UtkastStatusData = ({ status }: UtkastStatusDataProps) => {
-	let StatusIkon;
-	switch (status) {
-		case UtkastStatus.TRENGER_BESLUTTER:
-			StatusIkon = (
-				<Bleed marginBlock="1 2" asChild>
-					<PersonPlusIcon title="Trenger kvalitetssikrer-ikon" className="status_ikon" />
-				</Bleed>
-			);
-			break;
-		case UtkastStatus.KLAR_TIL_BESLUTTER:
-			StatusIkon = (
-				<Bleed marginBlock="0 3" asChild>
-					<ChatExclamationmarkIcon title="Venter på tilbakemelding-ikon" className="status_ikon" />
-				</Bleed>
-			);
-			break;
-		case UtkastStatus.KLAR_TIL_VEILEDER:
-			StatusIkon = (
-				<Bleed marginBlock="0 3" asChild>
-					<ChatElipsisIcon title="Venter på veileder-ikon" className="status_ikon" />
-				</Bleed>
-			);
-			break;
-		case UtkastStatus.GODKJENT_AV_BESLUTTER:
-			StatusIkon = (
-				<Bleed marginBlock="0 3" asChild>
-					<ChatElipsisIcon title="Godkjent av kvalitetssikrer-ikon" className="status_ikon" />
-				</Bleed>
-			);
-			break;
-	}
-
-	return (
-		<span role="cell" className={'status'}>
-			{StatusIkon}
-			<BodyShort size="small">{mapBrukerStatusTilTekst(status)}</BodyShort>
-		</span>
 	);
 };

--- a/src/components/user-table/bruker-direktelenke-med-feilmelding.tsx
+++ b/src/components/user-table/bruker-direktelenke-med-feilmelding.tsx
@@ -38,7 +38,7 @@ export const BrukerDirektelenkeMedFeilmelding = ({ enhet, fnr, knappTekst }: Bru
 		const basePath = finnBasePath();
 		const oppfolgingsvedtakSide = '/vedtaksstotte';
 		const queryParams = enhet ? `?enhet=${enhet}` : '';
-		const anchorParams = '#visVedtaksstotte#visUtkast';
+		const anchorParams = '#visUtkast';
 
 		return `${basePath}${oppfolgingsvedtakSide}${queryParams}${anchorParams}`;
 	};

--- a/src/components/user-table/bruker-direktelenke-med-feilmelding.tsx
+++ b/src/components/user-table/bruker-direktelenke-med-feilmelding.tsx
@@ -27,14 +27,15 @@ export const BrukerDirektelenkeMedFeilmelding = ({ enhet, fnr, knappTekst }: Bru
 			env.isDevelopment || env.isLocal
 				? 'https://veilarbpersonflate.intern.dev.nav.no'
 				: 'https://veilarbpersonflate.intern.nav.no';
+		const oppfolgingsvedtakSide = '/vedtaksstotte';
 		const queryParams = enhet ? `?enhet=${enhet}` : '';
 		const anchorParams = '#visVedtaksstotte#visUtkast';
 
 		const { hostname } = window.location;
 		if (hostname.includes('ansatt.dev.nav.no')) {
-			return `https://veilarbpersonflate.ansatt.dev.nav.no${queryParams}${anchorParams}`;
+			return `https://veilarbpersonflate.ansatt.dev.nav.no${oppfolgingsvedtakSide}${queryParams}${anchorParams}`;
 		}
-		return `${basePath}${queryParams}${anchorParams}`;
+		return `${basePath}${oppfolgingsvedtakSide}${queryParams}${anchorParams}`;
 	};
 
 	const handleClick = () => {

--- a/src/components/user-table/bruker-direktelenke-med-feilmelding.tsx
+++ b/src/components/user-table/bruker-direktelenke-med-feilmelding.tsx
@@ -1,19 +1,19 @@
 import { useRef, useState } from 'react';
+import { BodyShort, Button, Popover } from '@navikt/ds-react';
+import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
 import { useEventListener } from '../../hooks/use-event-listener';
 import { vedKlikkUtenfor } from '../../utils';
 import { lagSettBrukerIKontekstFetchInfo } from '../../rest/api';
 import { FetchState, hasFailed } from '../../rest/utils';
-import { BodyShort, Button, Popover } from '@navikt/ds-react';
-import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
 import useFetch from '../../rest/use-fetch';
 import env from '../../utils/environment';
 
-type BrukerDirektelenkeMedFeilmeldingProps = {
+interface Props {
 	fnr: string;
 	knappTekst: string;
-};
+}
 
-export const BrukerDirektelenkeMedFeilmelding = ({ fnr, knappTekst }: BrukerDirektelenkeMedFeilmeldingProps) => {
+export const BrukerDirektelenkeMedFeilmelding = ({ fnr, knappTekst }: Props) => {
 	const [popoverErApen, setPopoverErApen] = useState(false);
 	const knappeRef = useRef<HTMLButtonElement>(null);
 	const popoverRef = useRef<HTMLDivElement>(null);

--- a/src/components/user-table/bruker-direktelenke-med-feilmelding.tsx
+++ b/src/components/user-table/bruker-direktelenke-med-feilmelding.tsx
@@ -2,7 +2,6 @@ import { useRef, useState } from 'react';
 import { useEventListener } from '../../hooks/use-event-listener';
 import { vedKlikkUtenfor } from '../../utils';
 import { lagSettBrukerIKontekstFetchInfo } from '../../rest/api';
-import { OrNothing } from '../../utils/types/ornothing';
 import { FetchState, hasFailed } from '../../rest/utils';
 import { BodyShort, Button, Popover } from '@navikt/ds-react';
 import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
@@ -10,12 +9,11 @@ import useFetch from '../../rest/use-fetch';
 import env from '../../utils/environment';
 
 type BrukerDirektelenkeMedFeilmeldingProps = {
-	enhet: OrNothing<string>;
 	fnr: string;
 	knappTekst: string;
 };
 
-export const BrukerDirektelenkeMedFeilmelding = ({ enhet, fnr, knappTekst }: BrukerDirektelenkeMedFeilmeldingProps) => {
+export const BrukerDirektelenkeMedFeilmelding = ({ fnr, knappTekst }: BrukerDirektelenkeMedFeilmeldingProps) => {
 	const [popoverErApen, setPopoverErApen] = useState(false);
 	const knappeRef = useRef<HTMLButtonElement>(null);
 	const popoverRef = useRef<HTMLDivElement>(null);
@@ -34,13 +32,12 @@ export const BrukerDirektelenkeMedFeilmelding = ({ enhet, fnr, knappTekst }: Bru
 		return 'https://veilarbpersonflate.intern.nav.no';
 	};
 
-	const lagOppfolgingsvedtakDyplenke = (enhet: OrNothing<string>) => {
+	const lagOppfolgingsvedtakDyplenke = () => {
 		const basePath = finnBasePath();
 		const oppfolgingsvedtakSide = '/vedtaksstotte';
-		const queryParams = enhet ? `?enhet=${enhet}` : '';
 		const anchorParams = '#visUtkast';
 
-		return `${basePath}${oppfolgingsvedtakSide}${queryParams}${anchorParams}`;
+		return `${basePath}${oppfolgingsvedtakSide}${anchorParams}`;
 	};
 
 	const handleClick = () => {
@@ -49,7 +46,7 @@ export const BrukerDirektelenkeMedFeilmelding = ({ enhet, fnr, knappTekst }: Bru
 		} else {
 			settBrukerIKontekstFetcher.fetch(fnr, (state: FetchState) => {
 				if (!hasFailed(state)) {
-					window.location.href = lagOppfolgingsvedtakDyplenke(enhet);
+					window.location.href = lagOppfolgingsvedtakDyplenke();
 				}
 			});
 		}

--- a/src/components/user-table/bruker-direktelenke-med-feilmelding.tsx
+++ b/src/components/user-table/bruker-direktelenke-med-feilmelding.tsx
@@ -22,19 +22,24 @@ export const BrukerDirektelenkeMedFeilmelding = ({ enhet, fnr, knappTekst }: Bru
 
 	const settBrukerIKontekstFetcher = useFetch<void, string>(lagSettBrukerIKontekstFetchInfo);
 
+	const finnBasePath = (): string => {
+		const { hostname } = window.location;
+		if (hostname.includes('ansatt.dev.nav.no')) {
+			return 'https://veilarbpersonflate.ansatt.dev.nav.no';
+		}
+		if (env.isDevelopment || env.isLocal) {
+			return 'https://veilarbpersonflate.intern.dev.nav.no';
+		}
+
+		return 'https://veilarbpersonflate.intern.nav.no';
+	};
+
 	const lagOppfolgingsvedtakDyplenke = (enhet: OrNothing<string>) => {
-		const basePath =
-			env.isDevelopment || env.isLocal
-				? 'https://veilarbpersonflate.intern.dev.nav.no'
-				: 'https://veilarbpersonflate.intern.nav.no';
+		const basePath = finnBasePath();
 		const oppfolgingsvedtakSide = '/vedtaksstotte';
 		const queryParams = enhet ? `?enhet=${enhet}` : '';
 		const anchorParams = '#visVedtaksstotte#visUtkast';
 
-		const { hostname } = window.location;
-		if (hostname.includes('ansatt.dev.nav.no')) {
-			return `https://veilarbpersonflate.ansatt.dev.nav.no${oppfolgingsvedtakSide}${queryParams}${anchorParams}`;
-		}
 		return `${basePath}${oppfolgingsvedtakSide}${queryParams}${anchorParams}`;
 	};
 

--- a/src/components/user-table/user-table.tsx
+++ b/src/components/user-table/user-table.tsx
@@ -9,10 +9,10 @@ import Spinner from '../felles/spinner/spinner';
 import './user-table.less';
 
 export const UserTable = () => {
-	const { brukereFetcher, aktivEnhetFetcher } = useDataFetcherStore();
+	const { brukereFetcher } = useDataFetcherStore();
 	const { orderByField, orderByDirection, setOrderByField, setOrderByDirection } = useSokStore();
 	const tableBrukere = (brukereFetcher.data && brukereFetcher.data.brukere) || [];
-	const aktivEnhet = aktivEnhetFetcher.data ? aktivEnhetFetcher.data.aktivEnhet : undefined;
+
 	const orderByData: OrderByData = {
 		field: orderByField,
 		direction: orderByDirection
@@ -28,7 +28,7 @@ export const UserTable = () => {
 			if (tableBrukere.length === 0) {
 				return <Alert variant="info">Fant ingen brukere</Alert>;
 			} else {
-				return <UserTableBody brukere={tableBrukere} aktivEnhet={aktivEnhet} />;
+				return <UserTableBody brukere={tableBrukere} />;
 			}
 		}
 	};

--- a/src/components/user-table/user-table.tsx
+++ b/src/components/user-table/user-table.tsx
@@ -1,5 +1,5 @@
-import { UserTableHeader } from './header/user-table-header';
 import { Alert } from '@navikt/ds-react';
+import { UserTableHeader } from './header/user-table-header';
 import { UserTableBody } from './body/user-table-body';
 import { OrderByData } from './table-utils';
 import { useSokStore } from '../../stores/sok-store';


### PR DESCRIPTION
Før: kom til aktivitetsplanen.
No: kjem fram til oppfølgingsvedtak, oftast det aktuelle vedtaket som skal kvalitetssikrast.


Har også forenkla logikken for å setje basePath litt, ved å samle alt (dev, prod, ansatt) i same funksjon.