### PR TITLE
Rydd i ikon for utkaststatus

### DIFF
--- a/src/components/filters/status-dropdown/status-dropdown.tsx
+++ b/src/components/filters/status-dropdown/status-dropdown.tsx
@@ -5,25 +5,13 @@ import { useSokStore } from '../../../stores/sok-store';
 import { utkaststatusTekstOgIkon } from '../../user-table/body/status/utkast-status-data';
 import '../filters.css';
 
-export function mapStatusTilDropdownOption(status: UtkastStatus): DropdownOption {
-	return { value: status, label: utkaststatusTekstOgIkon[status].tekst };
-}
-
-interface DropdownOption {
-	value: string;
-	label: string;
-}
-
-const statusOptions: DropdownOption[] = [
-	mapStatusTilDropdownOption(UtkastStatus.TRENGER_BESLUTTER),
-	mapStatusTilDropdownOption(UtkastStatus.KLAR_TIL_VEILEDER),
-	mapStatusTilDropdownOption(UtkastStatus.KLAR_TIL_BESLUTTER)
-];
-
 export const StatusDropdown = () => {
 	const { filters, setStatusFilter } = useSokStore();
 	const value = filters?.status ?? undefined;
 	const selectRef = useRef<HTMLSelectElement>(null);
+	const statuserSomSkalVareValgbareIDropdown: UtkastStatus[] = Object.values(UtkastStatus).filter(
+		status => status != UtkastStatus.GODKJENT_AV_BESLUTTER
+	);
 
 	function handleOnStatusSelectedChanged(selectedOption: React.ChangeEvent<HTMLSelectElement>) {
 		const nyStatus = selectedOption.target.value as UtkastStatus;
@@ -47,9 +35,9 @@ export const StatusDropdown = () => {
 				ref={selectRef}
 			>
 				<option value={''}>Velg status</option>
-				{statusOptions.map(value => (
-					<option key={value.value} value={value.value}>
-						{value.label}
+				{statuserSomSkalVareValgbareIDropdown.map(status => (
+					<option key={status} value={status}>
+						{utkaststatusTekstOgIkon[status].tekst}
 					</option>
 				))}
 			</Select>

--- a/src/components/filters/status-dropdown/status-dropdown.tsx
+++ b/src/components/filters/status-dropdown/status-dropdown.tsx
@@ -1,12 +1,12 @@
 import { useRef } from 'react';
-import { UtkastStatus } from '../../../rest/data/bruker';
-import { mapBrukerStatusTilTekst } from '../../../utils';
-import { useSokStore } from '../../../stores/sok-store';
 import { Button, HStack, Select } from '@navikt/ds-react';
+import { UtkastStatus } from '../../../rest/data/bruker';
+import { useSokStore } from '../../../stores/sok-store';
+import { utkaststatusTekstOgIkon } from '../../user-table/body/status/utkast-status-data';
 import '../filters.css';
 
 export function mapStatusTilDropdownOption(status: UtkastStatus): DropdownOption {
-	return { value: status, label: mapBrukerStatusTilTekst(status) };
+	return { value: status, label: utkaststatusTekstOgIkon[status].tekst };
 }
 
 interface DropdownOption {

--- a/src/components/internflate-decorator/internflate-decorator.tsx
+++ b/src/components/internflate-decorator/internflate-decorator.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import NAVSPA from '@navikt/navspa';
-import { DecoratorConfig } from './internflate-decorator-config';
-import { erGCP } from '../../rest/utils';
-import { DecoratorPropsV3, Enhet, Environment } from './internflate-decorator-v3-config';
+import { DecoratorPropsV3, Environment } from './internflate-decorator-v3-config';
 
 const Decorator: React.ComponentType<DecoratorPropsV3> = NAVSPA.importer<DecoratorPropsV3>(
 	'internarbeidsflate-decorator-v3'

--- a/src/components/user-table/body/status/utkast-status-data.tsx
+++ b/src/components/user-table/body/status/utkast-status-data.tsx
@@ -20,7 +20,7 @@ export const utkaststatusTekstOgIkon: { [key in UtkastStatus]: { tekst: string; 
 		tekst: 'Trenger kvalitetssikring',
 		ikon: (
 			<Bleed marginBlock="1 2" asChild>
-				<PersonPlusIcon title="Trenger kvalitetssikrer-ikon" className="status_ikon" />
+				<PersonPlusIcon aria-hidden={true} className="status_ikon" />
 			</Bleed>
 		)
 	},
@@ -28,7 +28,7 @@ export const utkaststatusTekstOgIkon: { [key in UtkastStatus]: { tekst: string; 
 		tekst: 'Venter på tilbakemelding',
 		ikon: (
 			<Bleed marginBlock="0 3" asChild>
-				<ChatExclamationmarkIcon title="Venter på tilbakemelding-ikon" className="status_ikon" />
+				<ChatExclamationmarkIcon aria-hidden={true} className="status_ikon" />
 			</Bleed>
 		)
 	},
@@ -36,7 +36,7 @@ export const utkaststatusTekstOgIkon: { [key in UtkastStatus]: { tekst: string; 
 		tekst: 'Venter på veileder',
 		ikon: (
 			<Bleed marginBlock="0 3" asChild>
-				<ChatElipsisIcon title="Venter på veileder-ikon" className="status_ikon" />
+				<ChatElipsisIcon aria-hidden={true} className="status_ikon" />
 			</Bleed>
 		)
 	},
@@ -44,7 +44,7 @@ export const utkaststatusTekstOgIkon: { [key in UtkastStatus]: { tekst: string; 
 		tekst: 'Klar til utsendelse',
 		ikon: (
 			<Bleed marginBlock="0 3" asChild>
-				<ChatElipsisIcon title="Godkjent av kvalitetssikrer-ikon" className="status_ikon" />
+				<ChatElipsisIcon aria-hidden={true} className="status_ikon" />
 			</Bleed>
 		)
 	}

--- a/src/components/user-table/body/status/utkast-status-data.tsx
+++ b/src/components/user-table/body/status/utkast-status-data.tsx
@@ -1,50 +1,51 @@
 import { Bleed, BodyShort } from '@navikt/ds-react';
 import { ChatElipsisIcon, ChatExclamationmarkIcon, PersonPlusIcon } from '@navikt/aksel-icons';
 import { UtkastStatus } from '../../../../rest/data/bruker';
-import { mapBrukerStatusTilTekst } from '../../../../utils';
 
 interface Props {
 	status: UtkastStatus;
 }
 
 export const UtkastStatusData = ({ status }: Props) => {
-	let StatusIkon;
-
-	switch (status) {
-		case UtkastStatus.TRENGER_BESLUTTER:
-			StatusIkon = (
-				<Bleed marginBlock="1 2" asChild>
-					<PersonPlusIcon title="Trenger kvalitetssikrer-ikon" className="status_ikon" />
-				</Bleed>
-			);
-			break;
-		case UtkastStatus.KLAR_TIL_BESLUTTER:
-			StatusIkon = (
-				<Bleed marginBlock="0 3" asChild>
-					<ChatExclamationmarkIcon title="Venter på tilbakemelding-ikon" className="status_ikon" />
-				</Bleed>
-			);
-			break;
-		case UtkastStatus.KLAR_TIL_VEILEDER:
-			StatusIkon = (
-				<Bleed marginBlock="0 3" asChild>
-					<ChatElipsisIcon title="Venter på veileder-ikon" className="status_ikon" />
-				</Bleed>
-			);
-			break;
-		case UtkastStatus.GODKJENT_AV_BESLUTTER:
-			StatusIkon = (
-				<Bleed marginBlock="0 3" asChild>
-					<ChatElipsisIcon title="Godkjent av kvalitetssikrer-ikon" className="status_ikon" />
-				</Bleed>
-			);
-			break;
-	}
-
 	return (
-		<span role="cell" className={'status'}>
-			{StatusIkon}
-			<BodyShort size="small">{mapBrukerStatusTilTekst(status)}</BodyShort>
+		<span role="cell" className="status">
+			{utkaststatusTekstOgIkon[status].ikon}
+			<BodyShort size="small">{utkaststatusTekstOgIkon[status].tekst}</BodyShort>
 		</span>
 	);
+};
+
+const utkaststatusTekstOgIkon: { [key in UtkastStatus]: { tekst: string; ikon: React.ReactNode } } = {
+	[UtkastStatus.TRENGER_BESLUTTER]: {
+		tekst: 'Trenger kvalitetssikring',
+		ikon: (
+			<Bleed marginBlock="1 2" asChild>
+				<PersonPlusIcon title="Trenger kvalitetssikrer-ikon" className="status_ikon" />
+			</Bleed>
+		)
+	},
+	[UtkastStatus.KLAR_TIL_BESLUTTER]: {
+		tekst: 'Venter på tilbakemelding',
+		ikon: (
+			<Bleed marginBlock="0 3" asChild>
+				<ChatExclamationmarkIcon title="Venter på tilbakemelding-ikon" className="status_ikon" />
+			</Bleed>
+		)
+	},
+	[UtkastStatus.KLAR_TIL_VEILEDER]: {
+		tekst: 'Venter på veileder',
+		ikon: (
+			<Bleed marginBlock="0 3" asChild>
+				<ChatElipsisIcon title="Venter på veileder-ikon" className="status_ikon" />
+			</Bleed>
+		)
+	},
+	[UtkastStatus.GODKJENT_AV_BESLUTTER]: {
+		tekst: 'Klar til utsendelse',
+		ikon: (
+			<Bleed marginBlock="0 3" asChild>
+				<ChatElipsisIcon title="Godkjent av kvalitetssikrer-ikon" className="status_ikon" />
+			</Bleed>
+		)
+	}
 };

--- a/src/components/user-table/body/status/utkast-status-data.tsx
+++ b/src/components/user-table/body/status/utkast-status-data.tsx
@@ -15,7 +15,7 @@ export const UtkastStatusData = ({ status }: Props) => {
 	);
 };
 
-const utkaststatusTekstOgIkon: { [key in UtkastStatus]: { tekst: string; ikon: React.ReactNode } } = {
+export const utkaststatusTekstOgIkon: { [key in UtkastStatus]: { tekst: string; ikon: React.ReactNode } } = {
 	[UtkastStatus.TRENGER_BESLUTTER]: {
 		tekst: 'Trenger kvalitetssikring',
 		ikon: (

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,4 @@
-// tslint:disable-next-line:no-empty
-import { UtkastStatus } from '../rest/data/bruker';
-import { useEffect, useRef } from 'react';
-import { type RefObject } from 'react';
+import { type RefObject, useEffect, useRef } from 'react';
 
 export function usePrevious<T>(value: T) {
 	const ref = useRef<T>(value);
@@ -46,21 +43,6 @@ export function lagBrukerNavn(fornavn: string, etternavn: string): string {
 	}
 
 	return fornavn + ', ' + etternavn;
-}
-
-export function mapBrukerStatusTilTekst(status: UtkastStatus): string {
-	switch (status) {
-		case UtkastStatus.TRENGER_BESLUTTER:
-			return 'Trenger kvalitetssikring';
-		case UtkastStatus.KLAR_TIL_VEILEDER:
-			return 'Venter på veileder';
-		case UtkastStatus.KLAR_TIL_BESLUTTER:
-			return 'Venter på tilbakemelding';
-		case UtkastStatus.GODKJENT_AV_BESLUTTER:
-			return 'Klar til utsendelse';
-		default:
-			return '';
-	}
 }
 
 export const vedKlikkUtenfor = (refs: RefObject<HTMLElement>[], klikkTarget: Node | null, fn: () => void) => {


### PR DESCRIPTION
Eg har samla tekstar og ikon for utkaststatusar i eitt objekt, i staden for at det ligg litt her og litt der. Eg trur dette forenklar koden vår litt, fordi det trengs færre steg frå "eg har ein status" til "her er teksten til denne statusen".

Eg har også brukt aria-hidden på statusikona. Sidan dei alltid vert brukt saman med tekst tenker eg dei er å rekne som dekorative, og at skjermlesarar ikkje treng bry seg om dei. 