### PR TITLE
Gjer det tydelegare at testbrukarar er testbrukarar

### DIFF
--- a/src/mock/data/brukere.ts
+++ b/src/mock/data/brukere.ts
@@ -46,7 +46,7 @@ export const lagBrukere = (antallBrukere: number): Bruker[] => {
 			veilederNavn: faker.person.firstName() + ' ' + faker.person.lastName(),
 			brukerFnr: randomFnr(),
 			brukerFornavn: faker.person.firstName(),
-			brukerEtternavn: faker.person.lastName().toUpperCase(),
+			brukerEtternavn: 'Testson',
 			vedtakStartet: faker.date.recent({ days: 30 }).toISOString(),
 			brukerOppfolgingsenhetId: randomEnhet.enhetId,
 			brukerOppfolgingsenhetNavn: randomEnhet.navn,


### PR DESCRIPTION
Gjer det tydelegare at testbrukarar er testbrukarar ved å erstatte realistiske etternamn med "Testson".


Resultat av at ein veiledar som testa demoløysinga sendte inn spørsmål om "eeeeer dette ekte folk, eller?" 



Etter-bilete:
![image](https://github.com/user-attachments/assets/dccdbed9-ec10-47c3-8b55-51751e67df37)
