### PR TITLE
Endre tekst på knapp for å vise sakar veileder er kvalitetssikrar på

### DIFF
--- a/src/components/filters/bruker-filter/bruker-filter.tsx
+++ b/src/components/filters/bruker-filter/bruker-filter.tsx
@@ -11,7 +11,7 @@ export const BrukerFilter = () => {
 
 	return (
 		<Checkbox size="small" checked={filters.visMineBrukere} onChange={handleOnVisMineBrukereChanged}>
-			Mine brukere
+			Utkast jeg kvalitetssikrer
 		</Checkbox>
 	);
 };


### PR DESCRIPTION
Slik at det er lettare å forstå at "brukarar eg er veileder for" ikkje dukker opp saman med dei ein kvalitetssikrar, når ein filtrerer på dette valet.