### PR TITLE
La unleash-toggle vere med å styre visning av beslutteroversikt

### DIFF
--- a/.nais/obo-nais-dev.yaml
+++ b/.nais/obo-nais-dev.yaml
@@ -49,6 +49,8 @@ spec:
           namespace: obo
         - application: veilarbveileder
           namespace: obo
+        - application: obo-unleash
+          namespace: obo
   env:
     - name: JSON_CONFIG
       value: >
@@ -108,6 +110,16 @@ spec:
               "preserveFromPath": true,
               "toApp": {
                 "name": "veilarbvedtaksstotte",
+                "namespace": "obo",
+                "cluster": "dev-gcp"
+              }
+            },
+            {
+              "fromPath": "/obo-unleash",
+              "toUrl": "http://obo-unleash.obo",
+              "preserveFromPath": false,
+              "toApp": {
+                "name": "obo-unleash",
                 "namespace": "obo",
                 "cluster": "dev-gcp"
               }

--- a/.nais/obo-nais-prod.yaml
+++ b/.nais/obo-nais-prod.yaml
@@ -118,7 +118,7 @@ spec:
               "toApp": {
                 "name": "obo-unleash",
                 "namespace": "obo",
-                "cluster": "dev-gcp"
+                "cluster": "prod-gcp"
               }
             },
           ]

--- a/.nais/obo-nais-prod.yaml
+++ b/.nais/obo-nais-prod.yaml
@@ -46,6 +46,8 @@ spec:
           namespace: personoversikt
         - application: veilarbveileder
         - application: veilarbvedtaksstotte
+        - application: obo-unleash
+          namespace: obo
   env:
     - name: JSON_CONFIG
       value: >
@@ -108,6 +110,16 @@ spec:
                 "namespace": "obo",
                 "cluster": "prod-gcp"
               }
-            }
+            },
+            {
+              "fromPath": "/obo-unleash",
+              "toUrl": "http://obo-unleash.obo",
+              "preserveFromPath": false,
+              "toApp": {
+                "name": "obo-unleash",
+                "namespace": "obo",
+                "cluster": "dev-gcp"
+              }
+            },
           ]
         }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,10 +1,10 @@
 import StoreProvider from './stores/store-provider';
-
 import { InternflateDecorator } from './components/internflate-decorator/internflate-decorator';
 import { Hovedside } from './hovedside/hovedside';
 import { DataFetcher } from './components/datafetcher';
 import { useDataFetcherStore } from './stores/data-fetcher-store';
 import { PrelanseringInfoSide } from './prelansering-side/prelansering-side';
+import { VIS_VEDTAKSLOSNING_14A } from './rest/obo-unleash';
 
 function App() {
 	return (
@@ -18,10 +18,14 @@ function App() {
 }
 
 function Innhold() {
-	const { tilhorerVeilederUtrulletKontorFetcher } = useDataFetcherStore();
-	const harTilgang = tilhorerVeilederUtrulletKontorFetcher.data;
+	const { tilhorerVeilederUtrulletKontorFetcher, unleashFeaturetoggleFetcher } = useDataFetcherStore();
+	const veilederTilhorerUtrulletKontor = tilhorerVeilederUtrulletKontorFetcher.data;
+	const toggleForVisVedtakslosningErPaForVeileder = unleashFeaturetoggleFetcher.data[VIS_VEDTAKSLOSNING_14A];
 
-	return harTilgang ? <Hovedside /> : <PrelanseringInfoSide />;
+	const visInnholdForNyVedtakslosning14a =
+		veilederTilhorerUtrulletKontor || toggleForVisVedtakslosningErPaForVeileder;
+
+	return visInnholdForNyVedtakslosning14a ? <Hovedside /> : <PrelanseringInfoSide />;
 }
 
 export default App;

--- a/src/components/datafetcher.tsx
+++ b/src/components/datafetcher.tsx
@@ -1,12 +1,16 @@
 import { useEffect } from 'react';
+import { Alert } from '@navikt/ds-react';
 import { useDataFetcherStore } from '../stores/data-fetcher-store';
 import { hasAnyFailed, isAnyNotStartedOrPending, isNotStarted } from '../rest/utils';
-import { Alert } from '@navikt/ds-react';
 import Spinner from './felles/spinner/spinner';
 
 export function DataFetcher(props: { children: React.ReactNode }) {
-	const { innloggetVeilederFetcher, aktivEnhetFetcher, tilhorerVeilederUtrulletKontorFetcher } =
-		useDataFetcherStore();
+	const {
+		innloggetVeilederFetcher,
+		aktivEnhetFetcher,
+		tilhorerVeilederUtrulletKontorFetcher,
+		unleashFeaturetoggleFetcher
+	} = useDataFetcherStore();
 
 	useEffect(() => {
 		if (isNotStarted(innloggetVeilederFetcher)) {
@@ -20,15 +24,35 @@ export function DataFetcher(props: { children: React.ReactNode }) {
 		if (isNotStarted(tilhorerVeilederUtrulletKontorFetcher)) {
 			tilhorerVeilederUtrulletKontorFetcher.fetch(null);
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [innloggetVeilederFetcher, aktivEnhetFetcher, tilhorerVeilederUtrulletKontorFetcher]);
+
+		if (isNotStarted(unleashFeaturetoggleFetcher)) {
+			unleashFeaturetoggleFetcher.fetch(null);
+		}
+	}, [
+		innloggetVeilederFetcher,
+		aktivEnhetFetcher,
+		tilhorerVeilederUtrulletKontorFetcher,
+		unleashFeaturetoggleFetcher
+	]);
 
 	// Trenger ikke å sjekke om aktivEnhetFetcher er ferdig
 	if (
-		isAnyNotStartedOrPending([innloggetVeilederFetcher, aktivEnhetFetcher, tilhorerVeilederUtrulletKontorFetcher])
+		isAnyNotStartedOrPending([
+			innloggetVeilederFetcher,
+			aktivEnhetFetcher,
+			tilhorerVeilederUtrulletKontorFetcher,
+			unleashFeaturetoggleFetcher
+		])
 	) {
 		return <Spinner />;
-	} else if (hasAnyFailed([innloggetVeilederFetcher, aktivEnhetFetcher, tilhorerVeilederUtrulletKontorFetcher])) {
+	} else if (
+		hasAnyFailed([
+			innloggetVeilederFetcher,
+			aktivEnhetFetcher,
+			tilhorerVeilederUtrulletKontorFetcher,
+			unleashFeaturetoggleFetcher
+		])
+	) {
 		return (
 			<Alert variant="error">
 				Det oppnås for tiden ikke kontakt med alle baksystemer. Vi jobber med å løse saken. Vennligst prøv igjen

--- a/src/components/sok-sync.tsx
+++ b/src/components/sok-sync.tsx
@@ -6,6 +6,7 @@ import { hasFinishedWithData } from '../rest/utils';
 import { usePrevious } from '../utils';
 import { BeslutteroversiktSok } from '../rest/api';
 import { logMetrikk } from '../utils/logger';
+import { VIS_VEDTAKSLOSNING_14A } from '../rest/obo-unleash';
 
 function logSokMetrikker(sok: BeslutteroversiktSok, currentPage: number): void {
 	const filterMetrikker: any = {};
@@ -31,14 +32,17 @@ function logSokMetrikker(sok: BeslutteroversiktSok, currentPage: number): void {
 }
 
 export const SokSync = () => {
-	const { brukereFetcher, tilhorerVeilederUtrulletKontorFetcher } = useDataFetcherStore();
+	const { brukereFetcher, tilhorerVeilederUtrulletKontorFetcher, unleashFeaturetoggleFetcher } =
+		useDataFetcherStore();
 	const { filters, currentPage, pageSize, orderByDirection, orderByField, seeAll, setTotalPages, setCurrentPage } =
 		useSokStore();
 	const previousFilters = usePrevious(filters);
+	const skalViseVedtakslosning =
+		tilhorerVeilederUtrulletKontorFetcher.data || unleashFeaturetoggleFetcher.data?.[VIS_VEDTAKSLOSNING_14A];
 
 	useEffect(() => {
 		// Ikke søk hvis man ikke har tilgang til piloten
-		if (!tilhorerVeilederUtrulletKontorFetcher.data) {
+		if (!skalViseVedtakslosning) {
 			return;
 		}
 
@@ -52,7 +56,7 @@ export const SokSync = () => {
 		brukereFetcher.fetch({ sok });
 		logSokMetrikker(sok, currentPage);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [filters, currentPage, orderByDirection, orderByField, seeAll, tilhorerVeilederUtrulletKontorFetcher.data]);
+	}, [filters, currentPage, orderByDirection, orderByField, seeAll, skalViseVedtakslosning]);
 
 	useEffect(() => {
 		if (hasFinishedWithData(brukereFetcher)) {

--- a/src/mock/handlers/index.ts
+++ b/src/mock/handlers/index.ts
@@ -3,10 +3,12 @@ import { veilarbvedtaksstotteHandlers } from './veilarbvedtaksstotte';
 import { modiacontextholderHandlers } from './modiacontextholder';
 import { veilarbveilederHandlers } from './veilarbveileder';
 import { defaultHandlers } from './default';
+import { oboUnleashHandlers } from './mock-obo-unleash';
 
 export const allHandlers: RequestHandler[] = [
 	...veilarbvedtaksstotteHandlers,
 	...modiacontextholderHandlers,
 	...veilarbveilederHandlers,
-	...defaultHandlers
+	...defaultHandlers,
+	...oboUnleashHandlers
 ];

--- a/src/mock/handlers/mock-obo-unleash.ts
+++ b/src/mock/handlers/mock-obo-unleash.ts
@@ -1,0 +1,12 @@
+import { http, HttpResponse, RequestHandler } from 'msw';
+import { OboUnleashFeatures, VIS_VEDTAKSLOSNING_14A } from '../../rest/obo-unleash';
+
+const mockFeatures: OboUnleashFeatures = {
+	[VIS_VEDTAKSLOSNING_14A]: true
+};
+
+export const oboUnleashHandlers: RequestHandler[] = [
+	http.get('/obo-unleash/api/feature', async () => {
+		return HttpResponse.json(mockFeatures);
+	})
+];

--- a/src/rest/obo-unleash.ts
+++ b/src/rest/obo-unleash.ts
@@ -1,0 +1,28 @@
+import { FetchInfo } from './utils';
+
+export const VIS_VEDTAKSLOSNING_14A = 'veilarbvedtaksstotte.visVedtakslosning14a';
+
+export const ALL_TOGGLES = [VIS_VEDTAKSLOSNING_14A];
+
+export interface OboUnleashFeatures {
+	[VIS_VEDTAKSLOSNING_14A]: boolean;
+}
+
+export function lagHentUnleashFeaturetoggleInfo(): FetchInfo {
+	const features = ALL_TOGGLES.map(element => 'feature=' + element).join('&');
+	const url = `/obo-unleash/api/feature?${features}`;
+
+	const config: RequestInit = {
+		method: 'get',
+		credentials: 'same-origin',
+		headers: {
+			'Nav-Consumer-Id': 'beslutteroversikt',
+			'Content-Type': 'application/json'
+		}
+	};
+
+	return {
+		...config,
+		url
+	};
+}

--- a/src/stores/data-fetcher-store.ts
+++ b/src/stores/data-fetcher-store.ts
@@ -11,12 +11,20 @@ import { BrukereMedAntall } from '../rest/data/bruker';
 import { InnloggetVeileder } from '../rest/data/innlogget-veileder';
 import { AktivEnhet } from '../rest/data/aktiv-enhet';
 import { OrNothing } from '../utils/types/ornothing';
+import { lagHentUnleashFeaturetoggleInfo, OboUnleashFeatures } from '../rest/obo-unleash';
 
 export const [DataFetcherStoreProvider, useDataFetcherStore] = constate(() => {
 	const brukereFetcher = useFetch<BrukereMedAntall, { sok: BeslutteroversiktSok }>(lagHentBrukereFetchInfo);
 	const innloggetVeilederFetcher = useFetch<InnloggetVeileder>(lagHentInnloggetVeilederFetchInfo);
 	const aktivEnhetFetcher = useFetch<OrNothing<AktivEnhet>>(lagHentAktivEnhetFetchInfo);
 	const tilhorerVeilederUtrulletKontorFetcher = useFetch<boolean>(lagHentTilhorerVeilederUtrulletKontor);
+	const unleashFeaturetoggleFetcher = useFetch<OboUnleashFeatures>(lagHentUnleashFeaturetoggleInfo);
 
-	return { brukereFetcher, innloggetVeilederFetcher, aktivEnhetFetcher, tilhorerVeilederUtrulletKontorFetcher };
+	return {
+		brukereFetcher,
+		innloggetVeilederFetcher,
+		aktivEnhetFetcher,
+		tilhorerVeilederUtrulletKontorFetcher,
+		unleashFeaturetoggleFetcher
+	};
 });


### PR DESCRIPTION
"Kontortoggle" (utrullet for veileder) og "unleash-toggle" (visVedtakslosning14a) fungerer no i parallell slik at veileder løysinga om minst ein av dei er på, og ser prelanseringsinfo om er av.