### PR TITLE
Ignorer enhet til/fra context & dekorator

### DIFF
--- a/src/components/internflate-decorator/internflate-decorator-v3-config.ts
+++ b/src/components/internflate-decorator/internflate-decorator-v3-config.ts
@@ -7,6 +7,8 @@ export interface DecoratorPropsV3 {
 	enableHotkeys?: boolean | undefined; // Aktivere hurtigtaster
 	fetchActiveEnhetOnMount?: boolean | undefined; // Om enhet er undefined fra container appen, og denne er satt til true, henter den sist aktiv enhet og bruker denne.
 	fetchActiveUserOnMount?: boolean | undefined; // Om fnr er undefined fra container appen, og denne er satt til true for at den skal hente siste aktiv fnr.
+	fnrSyncMode?: 'sync' | 'writeOnly' | 'ignore';
+	enhetSyncMode?: 'sync' | 'writeOnly' | 'ignore';
 	onEnhetChanged: (enhetId?: string | null, enhet?: Enhet) => void; // Kalles når enheten endres
 	onFnrChanged: (fnr?: string | null) => void; // Kalles når fnr enheten endres
 	onLinkClick?: (link: { text: string; url: string }) => void; // Kan brukes for å legge til callbacks ved klikk på lenker i menyen. Merk at callbacken ikke kan awaites og man må selv håndtere at siden lukkes. Nyttig for å f.eks tracke navigasjon events i amplitude

--- a/src/components/internflate-decorator/internflate-decorator.tsx
+++ b/src/components/internflate-decorator/internflate-decorator.tsx
@@ -24,7 +24,8 @@ function lagDecoratorConfig(): DecoratorPropsV3 {
 		showSearchArea: false,
 		urlFormat: getEnv().ingressType === 'ansatt' ? 'ANSATT' : 'NAV_NO',
 		onEnhetChanged: () => {},
-		onFnrChanged: () => {}
+		onFnrChanged: () => {},
+		enhetSyncMode: 'ignore'
 	};
 }
 

--- a/src/mock/data/aktiv-enhet.ts
+++ b/src/mock/data/aktiv-enhet.ts
@@ -1,5 +1,28 @@
-import { AktivEnhet } from '../../rest/data/aktiv-enhet';
+import type { AktivEnhet } from '../../rest/data/aktiv-enhet';
 
 export const aktivEnhet: AktivEnhet = {
 	aktivEnhet: '1234'
+};
+
+export const modiaDecorator = {
+	saksbehandler: {
+		ident: 'Z999999',
+		fornavn: 'F_999999',
+		etternavn: 'E_999999',
+		navn: 'F_999999 E_999999'
+	},
+	enheter: [
+		{
+			enhetId: '1234',
+			navn: 'Test enhet'
+		},
+		{
+			enhetId: '1111',
+			navn: 'Annen test enhet'
+		}
+	],
+	ident: 'Z99999',
+	navn: 'F_999999 E_999999',
+	fornavn: 'F_999999',
+	etternavn: 'E_999999'
 };

--- a/src/mock/handlers/modiacontextholder.ts
+++ b/src/mock/handlers/modiacontextholder.ts
@@ -1,10 +1,13 @@
 import { MODIACONTEXTHOLDER_API } from '../../rest/api';
-import { aktivEnhet } from '../data/aktiv-enhet';
+import { aktivEnhet, modiaDecorator } from '../data/aktiv-enhet';
 import { http, HttpResponse, RequestHandler } from 'msw';
 
 export const modiacontextholderHandlers: RequestHandler[] = [
 	http.get(`${MODIACONTEXTHOLDER_API}/context/aktivenhet`, async () => {
 		return HttpResponse.json(aktivEnhet);
+	}),
+	http.get(`${MODIACONTEXTHOLDER_API}/decorator`, async () => {
+		return HttpResponse.json(modiaDecorator);
 	}),
 	http.post(`${MODIACONTEXTHOLDER_API}/context`, async () => {
 		return new HttpResponse(null, { status: 200 });


### PR DESCRIPTION
Slik at aktiv-enhet ikkje vert nullstilla til første enhet i dropdown når veileder navigerer mellom kvalitetssikring (beslutteroversikt) og oversikten/vedtaksstotte.